### PR TITLE
update URL to leave off the / at the end 

### DIFF
--- a/src/modules/DataManager.js
+++ b/src/modules/DataManager.js
@@ -1,6 +1,6 @@
 //from Former Nutshell project Data Managers.
 //const remoteURL = "https://state-quarters-api.herokuapp.com"
-const remoteURL = "https://state-quarters-collector.onrender.com/"
+const remoteURL = "https://state-quarters-collector.onrender.com"
 
 export default Object.create(null, {
     get: {


### PR DESCRIPTION
onrender's dashboard logs shows 

`/api` status 200, 
`/healthz` status 200, but 
`//users` has an extra / in it  brought in from datamanager.js

`const remoteURL = "https://state-quarters-collector.onrender.com/"`

`GET //users 304 0.495 ms - -`